### PR TITLE
Count physical CPUs by socket

### DIFF
--- a/src/provider/AbstractUnixProvider.php
+++ b/src/provider/AbstractUnixProvider.php
@@ -9,6 +9,7 @@ namespace probe\provider;
 abstract class AbstractUnixProvider extends AbstractProvider
 {
     protected $cpuInfo;
+	protected $cpuInfoByLsCpu;
     protected $memInfo;
     protected $sysctlInfo;
 

--- a/src/provider/LinuxProvider.php
+++ b/src/provider/LinuxProvider.php
@@ -123,15 +123,19 @@ class LinuxProvider extends AbstractUnixProvider
 	 */
 	public function getCpuinfoByLsCpu()
 	{
-        $lscpu = shell_exec('lscpu');
-        $lscpu = explode("\n", $lscpu);
-        $values = [];
-        foreach ($lscpu as $v) {
-            $v = array_map('trim', explode(':', $v));
-            if (isset($v[0], $v[1])) {
-                $values[$v[0]] = $v[1];
-            }
-        }
+		if (!$this->cpuInfoByLsCpu) {
+			$lscpu = shell_exec('lscpu');
+			$lscpu = explode("\n", $lscpu);
+			$values = [];
+			foreach ($lscpu as $v) {
+				$v = array_map('trim', explode(':', $v));
+				if (isset($v[0], $v[1])) {
+					$values[$v[0]] = $v[1];
+				}
+			}
+			$this->cpuInfoByLsCpu = $values;
+		}
+		return $this->cpuInfoByLsCpu;
 	}
 
     /**
@@ -160,8 +164,8 @@ class LinuxProvider extends AbstractUnixProvider
         $cu = $this->getCpuinfoByLsCpu();
         return array_key_exists('CPU(s)', $cu) ? $cu['CPU(s)'] : null;
     }
-	
-	/**
+    
+    /**
      * @inheritdoc
      */
     public function getCoresPerSocket()

--- a/src/provider/LinuxProvider.php
+++ b/src/provider/LinuxProvider.php
@@ -117,6 +117,22 @@ class LinuxProvider extends AbstractUnixProvider
         }
         return $this->cpuInfo;
     }
+	
+	/**
+	 * @inheritdoc
+	 */
+	public function getCpuinfoByLsCpu()
+	{
+        $lscpu = shell_exec('lscpu');
+        $lscpu = explode("\n", $lscpu);
+        $values = [];
+        foreach ($lscpu as $v) {
+            $v = array_map('trim', explode(':', $v));
+            if (isset($v[0], $v[1])) {
+                $values[$v[0]] = $v[1];
+            }
+        }
+	}
 
     /**
      * @inheritdoc
@@ -134,6 +150,24 @@ class LinuxProvider extends AbstractUnixProvider
     {
         $cu = $this->getCpuinfo();
         return array_key_exists('vendor_id', $cu) ? $cu['vendor_id'] : null;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPhysicalCpus()
+    {
+        $cu = $this->getCpuinfoByLsCpu();
+        return array_key_exists('CPU(s)', $cu) ? $cu['CPU(s)'] : null;
+    }
+	
+	/**
+     * @inheritdoc
+     */
+    public function getCoresPerSocket()
+    {
+        $cu = $this->getCpuinfoByLsCpu();
+        return array_key_exists('Core(s) per socket', $cu) ? $cu['Core(s) per socket'] : null;
     }
 
     /**


### PR DESCRIPTION
Some servers have more than 1 CPU. Probe only counts the cores for 1
CPU.

This update counts each socket, with the use of lscpu command, and also
counts cores per socket.
