### PR TITLE
Bug fix for getUsedMem() in LinuxProvider.php

### DIFF
--- a/src/provider/LinuxProvider.php
+++ b/src/provider/LinuxProvider.php
@@ -87,7 +87,7 @@ class LinuxProvider extends AbstractUnixProvider
      */
     public function getUsedMem()
     {
-        return $this->getTotalMem() - $this->getUsedMem();
+        return $this->getTotalMem() - $this->getFreeMem();
     }
 
     /**


### PR DESCRIPTION
This bug was causing nginx on my server to throw a 503 Gateway Timeout.

Hopefully, this fix returns the correct value of used RAM by subtracting
the free memory from the total.
